### PR TITLE
fix: substitute input variable in url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5.x
+          deno-version: v2.x
 
       - name: Get version from deno.json
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.3
+
+- Fixed variable substitution (`@@var@@`) in URLs when using `jsonr run`.
+
 # 4.2.2
 
 - Fixed tilde (`~`) expansion in secrets file path.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@sobanieca/jsonr",
   "description": "CLI tool for interacting with json http api's",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "license": "MIT",
   "exports": "./main.js",
   "compilerOptions": {

--- a/src/commands/send-request.js
+++ b/src/commands/send-request.js
@@ -174,8 +174,13 @@ export const sendRequest = async (args) => {
     );
   }
 
-  const urlOrFilePath = args["_"][0];
+  let urlOrFilePath = args["_"][0];
   const looksLikeFile = urlOrFilePath.endsWith(".http");
+
+  const variables = getVariables(args);
+  for (const [key, value] of variables) {
+    urlOrFilePath = urlOrFilePath.replaceAll(`@@${key}@@`, value);
+  }
 
   if (
     urlOrFilePath.startsWith("http://") || urlOrFilePath.startsWith("https://")
@@ -188,7 +193,6 @@ export const sendRequest = async (args) => {
     try {
       await Deno.lstat(urlOrFilePath);
       logger.debug(`File ${urlOrFilePath} found. Parsing http file content.`);
-      const variables = getVariables(args);
       const fileRequest = await parseHttpFile(
         urlOrFilePath,
         variables,

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const version = "4.2.2";
+export const version = "4.2.3";

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1301,3 +1301,25 @@ snapshot[`Given API 31`] = `
   outputError: "",
 }
 `;
+
+snapshot[`Given API 32`] = `
+{
+  code: 0,
+  jsonrCommand: "jsonr run jsonr-script-with-url-var.js -e test",
+  output: "GET http://localhost:3000/sample...
+" +
+    "Response:
+" +
+    "
+" +
+    '{ id: "sample-get" }
+' +
+    "200 - OK obtained in *ms
+" +
+    'Response: { id: "sample-get" }
+' +
+    "Status: 200
+",
+  outputError: "",
+}
+`;

--- a/test/requests/api1/jsonr-script-with-url-var.js
+++ b/test/requests/api1/jsonr-script-with-url-var.js
@@ -1,0 +1,5 @@
+// @ts-nocheck: jsonr specific script file
+const response = await jsonr("@@baseUrl@@/sample");
+
+console.log("Response:", response.body);
+console.log("Status:", response.status);

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,10 @@ Deno.test("Given API", async (t) => {
   await test("jsonr run jsonr-script.js", "test/requests");
   await test("jsonr run jsonr-script.js -v", "test/requests");
   await test("jsonr run jsonr-script.js -e test -v", "test/requests/api1");
+  await test(
+    "jsonr run jsonr-script-with-url-var.js -e test",
+    "test/requests/api1",
+  );
 
   apiProcess.kill();
   await apiProcess.output();


### PR DESCRIPTION
Fix for substituting input variable in url.

Restored 2.x version of Deno in CI:
Closes #16
